### PR TITLE
bug fix for the recursive pattern resolver

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ function GrokPattern(expression, id) {
     var t = this;
     t.id = id;
     t.expression = expression;
-    t.fields = [];
+    t.fields = [ null ]; // add a dummy entry at the beginning to swallow the fully captured expression
     t.resolved = null;
     t.regex = null;
 
@@ -18,14 +18,14 @@ function GrokPattern(expression, id) {
         }
 
         t.regexp.search(str, function(err, result) {
-            var i = 0;
             var r = {};
 
-            if (!err && result && result.filter) {
-                result.filter(function (item) {
-                    return item.match;
-                }).splice(1).forEach(function(item) {
-                    r[t.fields[i++]] = item.match;
+            if (!err && result) {
+                result.forEach(function(item, index) {
+                    var field = t.fields[index];
+                    if(field && item.match) {
+                        r[field] = item.match;
+                    }
                 });
             }
 
@@ -34,62 +34,81 @@ function GrokPattern(expression, id) {
     };
 }
 
-var nestedPatternsRegex = /%\{[A-Z0-9_]+(?::[a-z0-9_]+)?\}|\(\?<[a-z0-9]+>/g;
+var subPatternsRegex      = /%\{[A-Z0-9_]+(?::[a-z0-9_]+)?\}/g; // %{subPattern} or %{subPattern:fieldName}
+var nestedFieldNamesRegex = /(\(\?<([a-z0-9_]+)>)|\(\?:|\(\?>|\(\?!|\(\?<!|\(|\\\(|\\\)|\)|\[|\\\[|\\\]|\]/g
+
 function GrokCollection() {
     var t = this;
 
     var patterns = new Map();
 
-    function resolvePattern (pattern, isSubPattern) {
-        // detect references to other patterns
-        var expression = pattern.expression;
-        var subPatterns = expression.match(nestedPatternsRegex) || [];
-        subPatterns.forEach(function (subPatternName) {
-            var fieldName;
-            var isGrok = subPatternName.charAt(0) === '%';
+    function resolvePattern (pattern) {
+        pattern = resolveSubPatterns(pattern);
+        pattern = resolveFieldNames(pattern);
+        return pattern;
+    }
 
-            if (isGrok) {
-                subPatternName = subPatternName.substr(2, subPatternName.length - 3);
+    // detect references to other patterns
+    // TODO: support automatic type conversion (e.g., "%{NUMBER:duration:float}"; see: https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html)
+    function resolveSubPatterns (pattern) {
+        if(!pattern) { return; }
 
-                var elements = subPatternName.split(':');
-                if (elements.length > 1) {
-                    // has field name
-                    subPatternName = elements[0];
-                    fieldName = elements[1];
-                    pattern.fields.push(fieldName);
-                }
+        var expression  = pattern.expression;
+        var subPatterns = expression.match(subPatternsRegex) || [];
 
-                var subPattern = patterns.get(subPatternName);
-                if (!subPattern) {
-                    console.log('Error: pattern "' + subPatternName + '" not found!');
-                    return;
-                }
+        subPatterns.forEach(function (matched) {
+            // matched is: %{subPatternName} or %{subPatternName:fieldName}
+            var subPatternName = matched.substr(2, matched.length - 3);
 
-                if (!subPattern.resolved) {
-                    resolvePattern(subPattern, true);
-                }
+            var elements   = subPatternName.split(':');
+            subPatternName = elements[0];
+            var fieldName  = elements[1];
 
-                if (fieldName) {
-                    if (isSubPattern) {
-                        expression = expression.replace('%{' + subPatternName + ':' + fieldName + '}', subPattern.resolved);
-                    } else {
-                        expression = expression.replace('%{' + subPatternName + ':' + fieldName + '}', '(' + subPattern.resolved + ')');
-                    }
-                } else {
-                    expression = expression.replace('%{' + subPatternName + '}', subPattern.resolved);
-                }
+            var subPattern = patterns.get(subPatternName);
+            if (!subPattern) {
+                console.error('Error: pattern "' + subPatternName + '" not found!');
+                return;
+            }
 
-                if (subPattern.fields.length) {
-                    //Array.prototype.push.apply(pattern.fields, subPattern.fields);
-                }
+            if (!subPattern.resolved) {
+                resolvePattern(subPattern);
+            }
+
+            if (fieldName) {
+                expression = expression.replace(matched, '(?<' + fieldName + '>' + subPattern.resolved + ')');
             } else {
-                fieldName = subPatternName.substr(3, subPatternName.length - 4);
-                pattern.fields.push(fieldName);
-                expression = expression.replace('?<' + fieldName + '>', '');
+                expression = expression.replace(matched, subPattern.resolved);
             }
         });
 
         pattern.resolved = expression;
+        return pattern;
+    }
+
+    // create mapping table for the fieldNames to capture
+    function resolveFieldNames (pattern) {
+        if(!pattern) { return; }
+
+        var nestLevel = 0;
+        var inRangeDef = 0;
+        var matched;
+        while ((matched = nestedFieldNamesRegex.exec(pattern.resolved)) !== null) {
+            switch(matched[0]) {
+                case '(':    { if(!inRangeDef) { ++nestLevel; pattern.fields.push(null); } break; }
+                case '\\(':  break; // can be ignored
+                case '\\)':  break; // can be ignored
+                case ')':    { if(!inRangeDef) { --nestLevel; } break; }
+                case '[':    { ++inRangeDef; break; }
+                case '\\[':  break; // can be ignored
+                case '\\]':  break; // can be ignored
+                case ']':    { --inRangeDef; break; }
+                case '(?:':  // fallthrough                              // group not captured
+                case '(?>':  // fallthrough                              // atomic group
+                case '(?!':  // fallthrough                              // negative look-ahead
+                case '(?<!': { if(!inRangeDef) { ++nestLevel; } break; } // negative look-behind
+                default:     { ++nestLevel; pattern.fields.push(matched[2]); break; }
+            }
+        }
 
         return pattern;
     }
@@ -97,7 +116,7 @@ function GrokCollection() {
     t.createPattern = function (expression, id) {
         id = id || 'pattern-' + patterns.length;
         if (patterns.has(id)) {
-            console.log('Error: pattern with id %s already exists', id);
+            console.error('Error: pattern with id %s already exists', id);
         } else {
             var pattern = new GrokPattern(expression, id);
             return resolvePattern(pattern);
@@ -142,7 +161,7 @@ module.exports = {
                     }),
                     function (err) {
                         if (err) {
-                            console.log('Error loading patterns: %s', err.message);
+                            console.error('Error loading patterns: %s', err.message);
                         }
                         callback(defaultPatterns);
                     });

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,9 +1,127 @@
 var grok = require('./index.js');
 var expect = require("chai").expect;
 
+function testParse(p, str, expected, done) {
+	grok.loadDefault(function (patterns) {
+		var pattern = patterns.createPattern(p);
+		pattern.parse(str, function (err, result) {
+			expect(err).to.be.null;
+			expect(result).to.be.eql(expected);
+			done();
+		});
+	});
+}
+
 describe('grok', function() {
 	describe('#parse()', function () {
-		it('should parse the given explicit pattern correctly', function (done) {
+		
+		it('should parse a simple custom pattern', function (done) {
+			var p   = '(?<verb>\\w+)\\s+(?<url>/\\w+)';
+			var str = 'DELETE /ping HTTP/1.1';
+			var expected = {
+				verb: 'DELETE',
+				url:  '/ping'
+			};
+
+			testParse(p, str, expected, done);
+		});
+		
+		it('should parse a pattern with some default patterns', function (done) {
+			var p   = '%{WORD:verb} %{URIPATH:url}';
+			var str = 'DELETE /ping HTTP/1.1';
+			var expected = {
+				verb: 'DELETE',
+				url:  '/ping'
+			};
+
+			testParse(p, str, expected, done);
+		});
+
+		it('should parse a pattern with optional parts correctly #1', function (done) {
+			var p   = '(?<all>(%{WORD:verb} %{URIPATH:url}|(?<alternative>\\(ALTERNATIVE\\))))';
+			var str = 'DELETE /ping HTTP/1.1';
+			var expected = {
+				all: 'DELETE /ping',
+				verb: 'DELETE',
+				url:  '/ping'
+			};
+
+			testParse(p, str, expected, done);
+		});
+
+		it('should parse a pattern with optional parts correctly #2', function (done) {
+			var p   = '(?<all>(%{WORD:verb} %{URIPATH:url}|(?<alternative>\\(ALTERNATIVE\\))))';
+			var str = '(ALTERNATIVE)';
+			var expected = {
+				all:         '(ALTERNATIVE)',
+				alternative: '(ALTERNATIVE)'
+			};
+
+			testParse(p, str, expected, done);
+		});
+		
+		
+		it('should parse parts of the default HAPROXYHTTP pattern', function (done) {
+			var p   = '(<BADREQ>|(%{WORD:http_verb} (%{URIPROTO:http_proto}://)?(?:%{USER:http_user}(?::[^@]*)?@)?(?:%{URIHOST:http_host})?(?:%{URIPATHPARAM:http_request})?( HTTP/%{NUMBER:http_version})?))';
+			var str = 'GET /ping HTTP/1.1';
+			var expected = {
+				http_verb:                'GET',
+				http_request:             '/ping',
+				http_version:             '1.1'
+			};
+
+			testParse(p, str, expected, done);
+		});
+
+		it('should parse the full default HAPROXYHTTP pattern', function (done) {
+			var p   = '%{HAPROXYHTTP:haproxy}';
+			var str = 'Aug 17 12:06:27 minion haproxy[3274]: 1.2.3.4:50901 [17/Aug/2015:12:06:27.379] http-in backend_gru/minion_8080 1/0/0/142/265 200 259 - - ---- 0/0/0/0/0 0/0 "GET /ping HTTP/1.1"';
+			var expected = {
+				haproxy:                  str,
+				syslog_timestamp:         'Aug 17 12:06:27',
+				syslog_server:            'minion',
+				pid:                      '3274',
+				program:                  'haproxy',
+				client_ip:                '1.2.3.4',
+				client_port:              '50901',
+				accept_date:              '17/Aug/2015:12:06:27.379',
+				haproxy_hour:             '12',
+				haproxy_milliseconds:     '379',
+				haproxy_minute:           '06',
+				haproxy_month:            'Aug',
+				haproxy_monthday:         '17',
+				haproxy_second:           '27',
+				haproxy_time:             '12:06:27',
+				haproxy_year:             '2015',
+				frontend_name:            'http-in',
+				backend_name:             'backend_gru',
+				server_name:              'minion_8080',
+				time_request:             '1',
+				time_queue:               '0',
+				time_backend_connect:     '0',
+				time_backend_response:    '142',
+				time_duration:            '265',
+				http_status_code:         '200',
+				bytes_read:               '259',
+				captured_request_cookie:  '-',
+				captured_response_cookie: '-',
+				termination_state:        '----',
+				actconn:                  '0',
+				feconn:                   '0',
+				beconn:                   '0',
+				srvconn:                  '0',
+				retries:                  '0',
+				srv_queue:                '0',
+				backend_queue:            '0',
+				http_verb:                'GET',
+				http_request:             '/ping',
+				http_version:             '1.1'
+			};
+
+			testParse(p, str, expected, done);
+		});
+
+		it('should parse the sample pattern of the README.md', function (done) {
 			var p   = '%{IP:client} \\[%{TIMESTAMP_ISO8601:timestamp}\\] "%{WORD:method} %{URIHOST:site}%{URIPATHPARAM:url}" %{INT:code} %{INT:request} %{INT:response} - %{NUMBER:took} \\[%{DATA:cache}\\] "%{DATA:mtag}" "%{DATA:agent}"';
 			var str = '65.19.138.33 [2015-05-13T08:04:43+10:00] "GET datasymphony.com.au/ru/feed/" 304 385 0 - 0.140 [HIT] "-" "Feedly/1.0 (+http://www.feedly.com/fetcher.html; like FeedFetcher-Google)"';
 			var expected = {
@@ -21,13 +139,8 @@ describe('grok', function() {
 				agent:     'Feedly/1.0 (+http://www.feedly.com/fetcher.html; like FeedFetcher-Google)'
 			};
 
-			grok.loadDefault(function (patterns) {
-			    var pattern = patterns.createPattern(p);
-			    pattern.parse(str, function (err, result) {
-			    	expect(result).to.be.eql(expected);
-			        done();
-			    });
-			});
+			testParse(p, str, expected, done);
 		});
+		
 	});
 });


### PR DESCRIPTION
bug fix for: https://github.com/Beh01der/node-grok/issues/1

I changed the resolver to first replace the `grok` patterns `%{subPattern:fieldName}` by the corresponding `oniguruma` named capture groups `(?<fieldName>...)` and then in a second pass create the `fields` array for all named capture groups taking the corresponding group nesting into account. Since there could be several unnamed capture groups as well, the `fields` array now contains `null` values for them. During the actual pattern parsing process these `null` fields are ignored.

I also added a bunch of additional unit tests in order to ensure the proper parsing of them.