### PR TITLE
Return raw result on parse callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ function GrokPattern(expression, id) {
                 });
             }
 
-            next(err, r);
+            next(err, r, result);
         });
     };
 }


### PR DESCRIPTION
The parse callback returns err=null obj={} on non-matches. This is a problem if the caller want's to know if the input data was a match.

Setting err=something or obj=null will break backwards compatibility, so my suggestion is adding a third callback argument.