### PR TITLE
updating collections package to @^2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "async": "^0.9.0",
-    "collections": "^1.2.3",
+    "collections": "^2.0",
     "line-reader": "^0.2.4",
     "oniguruma": "^5.1.1"
   },


### PR DESCRIPTION
there was a bug with Array.find that was giving us trouble (bug:
https://github.com/montagejs/collections/issues/139) and this bug is no
longer present in 2.0 version of collections.