### PR TITLE
FIX: Ignore pattern lines beginning with #

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -131,7 +131,7 @@ function GrokCollection() {
         return pattern;
     }
 
-    var patternLineRegex = /([A-Z0-9_]+)\s+(.+)/;
+    var patternLineRegex = /^([A-Z0-9_]+)\s+(.+)/;
     var splitLineRegex = /\r?\n/;
 
     function doLoad(filePath) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-grok",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Regular expression template library inspired by logstash grok filter module",
   "repository": "https://github.com/Beh01der/node-grok.git",
   "main": "./lib/index.js",


### PR DESCRIPTION
Regex was not matching from beginning of line, allowing the commented-out
#URIPARAM to be loaded, then immediately overwritten.